### PR TITLE
Fix JntArray size read if in a vector

### DIFF
--- a/include/kdl_msgs/Jacobian.h
+++ b/include/kdl_msgs/Jacobian.h
@@ -168,7 +168,9 @@ namespace serialization
     template<typename Stream, typename T>
     inline static void read(Stream& stream, T& m)
     {
-      std::size_t size = stream.getLength() / sizeof(typename T::value_type);
+      IStream peek_size_stream(stream.getData(), stream.getLength());
+      uint32_t size;
+      peek_size_stream.next(size);
       BOOST_ASSERT_MSG((size % 6) == 0, "Size of Jacobian must be a multiple of 6");
       m.resize(size / 6);
       deserialize(stream, m.data.data(), m.data.rows() * m.data.cols());

--- a/include/kdl_msgs/JntArray.h
+++ b/include/kdl_msgs/JntArray.h
@@ -169,9 +169,14 @@ namespace serialization
     template<typename Stream, typename T>
     inline static void read(Stream& stream, T& m)
     {
-      std::size_t size = stream.getLength() / sizeof(Eigen::VectorXd::Scalar);
-      m.resize(size);
-      deserialize(stream, m.data.data(), m.data.rows());
+      uint32_t len;
+      stream.next(len);
+      m.resize(len);
+
+      for (int i = 0 ; i < len ; i++)
+      {
+        stream.next(m(i));
+      }
     }
 
     template<typename T>

--- a/include/kdl_msgs/JntArray.h
+++ b/include/kdl_msgs/JntArray.h
@@ -169,14 +169,11 @@ namespace serialization
     template<typename Stream, typename T>
     inline static void read(Stream& stream, T& m)
     {
-      uint32_t len;
-      stream.next(len);
-      m.resize(len);
-
-      for (int i = 0 ; i < len ; i++)
-      {
-        stream.next(m(i));
-      }
+      IStream peek_size_stream(stream.getData(), stream.getLength());
+      uint32_t size;
+      peek_size_stream.next(size);
+      m.resize(size);
+      deserialize(stream, m.data.data(), m.data.rows());
     }
 
     template<typename T>


### PR DESCRIPTION
This PR fixes the calculation of the JntArray length if in a vector.
Example : 

`JointPath.msg` : 

```
kdl_msgs/JntArray[] joint_path
```

```
    kdl_msgs::JntArray j(6);
    j(0) = 0.0;
    j(1) = 1.0;
    j(2) = 2.0;
    j(3) = 3.0;
    j(4) = 4.0;
    j(5) = 5.0;

    test_msgs::JointPath path;
    path.push_back(j);
```

If only sending a JntArray message, at deserialize JntArray  : 
`std::size_t size = stream.getLength() / sizeof(Eigen::VectorXd::Scalar);` returns 6 (good)

If sending a Path message, at deserialize JntArray : 
`std::size_t size = stream.getLength() / sizeof(Eigen::VectorXd::Scalar);` returns 11 (bad!)

```
joint_path[]
  joint_path[0]: 
    data[]
      data[0]: 0
      data[1]: 1
      data[2]: 2
      data[3]: 3
      data[4]: 4
      data[5]: 5
      data[6]: 3.16202e-322
      data[7]: 2.37152e-322
      data[8]: 5.25348e-317
      data[9]: 1.13635e-322
      data[10]: 1.13635e-322
```

It's finally just the code inside `deserialize` put in the `Serializer< ::KDL::JntArray >::read` function, minus overhead.

